### PR TITLE
Add User Agent headers to requests

### DIFF
--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -2,7 +2,7 @@ module TeslaApi
   class Client
     include HTTParty
     base_uri "https://owner-api.teslamotors.com/api/1"
-    headers ({ "User-Agent" => "github.com/timdorr/model-s-api v:#{VERSION}" })
+    headers ({ "User-Agent" => "github.com/timdorr/tesla-api v:#{VERSION}" })
     format :json
 
     attr_reader :email, :token, :client_id, :client_secret

--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -2,6 +2,7 @@ module TeslaApi
   class Client
     include HTTParty
     base_uri "https://owner-api.teslamotors.com/api/1"
+    headers ({ "User-Agent" => "github.com/timdorr/model-s-api v:#{VERSION}" })
     format :json
 
     attr_reader :email, :token, :client_id, :client_secret
@@ -15,7 +16,6 @@ module TeslaApi
     def token=(token)
       @token = token
       self.class.headers "Authorization" => "Bearer #{token}"
-      self.class.headers "user-agent" => "007"  # Doesn't matter what value
     end
 
     def expires_in=(seconds)

--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -15,6 +15,7 @@ module TeslaApi
     def token=(token)
       @token = token
       self.class.headers "Authorization" => "Bearer #{token}"
+      self.class.headers "user-agent" => "007"  # Doesn't matter what value
     end
 
     def expires_in=(seconds)


### PR DESCRIPTION
Fix issue that surfaced on 29 Aug 2018 about 14:44 CDT, resulting in 'Our servers are waiting for a supercharger spot..' html msg instead of json data.  Fix inspired by https://teslamotorsclub.com/tmc/threads/error-in-tesla-api.127239/

Apologies that I haven't spent the time to learn and run and update the test suite successfully, but I did do a 'gem build' of model-s-api with this fix, copied the .gem to my repo, did a 'gem unpack', pointed to it from Gemfile, verified it locally, checked the unpacked gem and tweaked Gemfile into my repo, deployed to heroku, and verified that my website is now collecting my car data again.

Hope this helps!