### PR TITLE
Model S seems to show an option code of MS03

### DIFF
--- a/docs/vehicle/optioncodes.md
+++ b/docs/vehicle/optioncodes.md
@@ -12,7 +12,7 @@ appreciated!_
 
 | Code | Title | Description |
 | :--- | :--- | :--- |
-| MDLS | Model S | This vehicle is a Model S | 
+| MDLS or MS03 | Model S | This vehicle is a Model S | 
 | MDLX | Model X | This vehicle is a Model X | 
 | MDL3 | Model 3 | This vehicle is a Model 3 | 
 | RENA | Region: North America | | 


### PR DESCRIPTION
I am using the API and none of the documented model options are available in the "option_codes".  I am seeing "MSO3".  "MDLS", "MDL3", and "MDLX" are not available.  "api_version"=>6
Here are all of the "Option Codes I am getting back from our Model S via the API:  
"option_codes"=>"MS03,RENA,AD02,AU00,BC0B,BS00,BT85,CH00,PPMR,CW00,DRLH,FG01,HP00,HP03,IDPB,IX00,LP00,PA00,PF00,PK01,PS00,PX00,QPMB,RFPO,SC01,SP00,SU01,TM00,TP01,TR00,UTMF,WTTP,WTX1,X001,X003,X007,X011,X014,X021,X025,X027,X028,X031,X037,YF00,COUS",