### PR TITLE
 Add remote steering wheel heater requests

### DIFF
--- a/docs/vehicle/commands/climate.md
+++ b/docs/vehicle/commands/climate.md
@@ -77,3 +77,22 @@ The `heater` parameter maps to the following seats:
   "result": true
 }
 ```
+
+## POST `/api/1/vehicles/{id}/command/remote_steering_wheel_heater_request`
+
+Turn steering wheel heater on or off.
+
+### Parameters
+
+| Parameter | Example | Description                         |
+| :-------- | :------ | :---------------------------------- |
+| on        | true    | True to turn on, false to turn off. |
+
+### Response
+
+```json
+{
+  "reason": "",
+  "result": true
+}
+```

--- a/docs/vehicle/state/climatestate.md
+++ b/docs/vehicle/state/climatestate.md
@@ -24,6 +24,7 @@ Information on the current internal temperature and climate control system.
     "min_avail_temp": 15.0,
     "outside_temp": null,
     "passenger_temp_setting": 21.6,
+    "remote_heater_control_enabled": true,
     "right_temp_direction": null,
     "seat_heater_left": 3,
     "seat_heater_rear_center": 0,


### PR DESCRIPTION
Add documentation for creating a remote steering wheel heater request and update the response that climate state data requests return.

The new key in the climate state response, `remote_heater_control_enabled`, seems to just mirror the `is_climate_on` key.