### PR TITLE
Add MS04 option code for Model S.

### DIFF
--- a/docs/vehicle/optioncodes.md
+++ b/docs/vehicle/optioncodes.md
@@ -12,7 +12,7 @@ appreciated!_
 
 | Code | Title | Description |
 | :--- | :--- | :--- |
-| MDLS or MS03 | Model S | This vehicle is a Model S | 
+| MDLS or MS03 or MS04 | Model S | This vehicle is a Model S | 
 | MDLX | Model X | This vehicle is a Model X | 
 | MDL3 | Model 3 | This vehicle is a Model 3 | 
 | RENA | Region: North America | | 

--- a/docs/vehicle/optioncodes.md
+++ b/docs/vehicle/optioncodes.md
@@ -12,7 +12,9 @@ appreciated!_
 
 | Code | Title | Description |
 | :--- | :--- | :--- |
-| MDLS or MS03 or MS04 | Model S | This vehicle is a Model S | 
+| MDLS | Model S | This vehicle is a Model S | 
+| MS03 | Model S | This vehicle is a Model S | 
+| MS04 | Model S | This vehicle is a Model S | 
 | MDLX | Model X | This vehicle is a Model X | 
 | MDL3 | Model 3 | This vehicle is a Model 3 | 
 | RENA | Region: North America | | 


### PR DESCRIPTION
Seen in this option code string from a Model S 85D:

`MS04,RENA,AU00,BC0B,BS00,BT85,CDM0,CH00,PMSS,CW00,DA01,DRLH,DSH7,DV4W,FG02,HP00,IDHG,IX00,LP00,ME02,PA00,PF00,PI00,PK00,PS01,PX00,QPMG,RFBC,SC01,SP00,SR01,SU01,TM00,TP02,TR00,UTAB,WT19,WTX1,X001,X003,X007,X011,X014,X021,X025,X027,X028,X031,X037,YF00,COUS`

