### PR TITLE
Retrieve refresh_token from the OAuth login

### DIFF
--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -5,7 +5,7 @@ module TeslaApi
     headers 'User-Agent' => "github.com/timdorr/tesla-api v:#{VERSION}"
     format :json
 
-    attr_reader :email, :token, :client_id, :client_secret
+    attr_reader :email, :token, :refresh_token, :client_id, :client_secret
 
     def initialize(email, client_id = ENV['TESLA_CLIENT_ID'], client_secret = ENV['TESLA_CLIENT_SECRET'])
       @email = email
@@ -48,13 +48,18 @@ module TeslaApi
           }
       )
 
-      self.expires_in = response['expires_in']
-      self.created_at = response['created_at']
-      self.token      = response['access_token']
+      self.expires_in    = response['expires_in']
+      self.created_at    = response['created_at']
+      self.token         = response['access_token']
+      self.refresh_token = response['refresh_token']
     end
 
     def vehicles
       self.class.get('/vehicles')['response'].map { |v| Vehicle.new(self.class, email, v['id'], v) }
     end
+
+    private
+
+    attr_writer :refresh_token
   end
 end

--- a/lib/tesla_api/version.rb
+++ b/lib/tesla_api/version.rb
@@ -1,3 +1,3 @@
 module TeslaApi
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end

--- a/lib/tesla_api/version.rb
+++ b/lib/tesla_api/version.rb
@@ -1,3 +1,3 @@
 module TeslaApi
-  VERSION = '1.4.2'
+  VERSION = '1.4.1'
 end

--- a/spec/cassettes/client-login.yml
+++ b/spec/cassettes/client-login.yml
@@ -42,7 +42,7 @@ http_interactions:
       - '0.416152'
     body:
       encoding: UTF-8
-      string: '{"access_token":"1cba4845a8653d4b731440e9911d84304a179bd16a9ecbc9b649f2d8e0f6947e","token_type":"bearer","expires_in":7776000,"created_at":1475777133}'
-    http_version: 
+      string: '{"access_token":"1cba4845a8653d4b731440e9911d84304a179bd16a9ecbc9b649f2d8e0f6947e","token_type":"bearer","expires_in":7776000,"refresh_token":"fea03b395fa4e72ebc399d9cda6163dcf438c248f744ebdd5bfcda571f5f317f","created_at":1475777133}'
+    http_version:
   recorded_at: Mon, 15 Dec 2014 03:09:22 GMT
 recorded_with: VCR 2.9.3

--- a/spec/lib/tesla_api/client_spec.rb
+++ b/spec/lib/tesla_api/client_spec.rb
@@ -54,6 +54,11 @@ RSpec.describe TeslaApi::Client do
       tesla_api.login!(ENV['TESLA_PASS'])
       expect(tesla_api.token).to match(/[a-z0-9]{32}/)
     end
+
+    it 'obtains a refresh token' do
+      tesla_api.login!(ENV['TESLA_PASS'])
+      expect(tesla_api.refresh_token).to match(/[a-z0-9]{32}/)
+    end
   end
 
   describe '#vehicles', vcr: {cassette_name: 'client-vehicles'} do


### PR DESCRIPTION
The `refresh_token` that is provided from the OAuth login is not used in the base repository.
I need to be able to request a new `access_token`, but this only works by having the `refresh_token`
available.