### PR TITLE
Retry request on timeouts

### DIFF
--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -10,7 +10,8 @@ module TeslaApi
         access_token_expires_at: nil,
         refresh_token: nil,
         client_id: ENV['TESLA_CLIENT_ID'],
-        client_secret: ENV['TESLA_CLIENT_SECRET']
+        client_secret: ENV['TESLA_CLIENT_SECRET'],
+        retry_options: nil
     )
       @email = email
 
@@ -28,6 +29,7 @@ module TeslaApi
         conn.request :json
         conn.response :json
         conn.response :raise_error
+        conn.request :retry, retry_options if retry_options # Must be registered after :raise_error
         conn.adapter Faraday.default_adapter
       end
     end

--- a/spec/cassettes/client-login_timeout.yml
+++ b/spec/cassettes/client-login_timeout.yml
@@ -1,0 +1,83 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://owner-api.teslamotors.com/oauth/token
+    body:
+      encoding: UTF-8
+      string: grant_type=password&client_id=<TESLA_CLIENT_ID>&client_secret=<TESLA_CLIENT_SECRET>&email=<TESLA_EMAIL>&password=<TESLA_PASS>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 408
+      message: Request Timeout
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 15 Dec 2014 03:09:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 408 Request Timeout
+    body:
+      encoding: UTF-8
+      string: '{}'
+    http_version:
+  recorded_at: Mon, 15 Dec 2014 03:09:22 GMT
+- request:
+    method: post
+    uri: https://owner-api.teslamotors.com/oauth/token
+    body:
+      encoding: UTF-8
+      string: grant_type=password&client_id=<TESLA_CLIENT_ID>&client_secret=<TESLA_CLIENT_SECRET>&email=<TESLA_EMAIL>&password=<TESLA_PASS>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 15 Dec 2014 03:09:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-store
+      Pragma:
+      - no-cache
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Request-Id:
+      - 349d563d345a9694c610770b743d3006
+      X-Runtime:
+      - '0.416152'
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"1cba4845a8653d4b731440e9911d84304a179bd16a9ecbc9b649f2d8e0f6947e","token_type":"bearer","expires_in":7776000,"refresh_token":"fea03b395fa4e72ebc399d9cda6163dcf438c248f744ebdd5bfcda571f5f317f","created_at":1475777133}'
+    http_version:
+  recorded_at: Mon, 15 Dec 2014 03:09:22 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
Using this awesome gem, we discovered that sometimes API calls fail due to timeout/load related errors on Tesla's API side.

We especially recorded:
- 408 Request Timeout
- 502 Bad Gateway

in maybe 1 in 100 calls.


This pull requests enables the Faraday retry feature and therefore retries any request up to 3 times with a pause of 0.5 seconds between each trial (increasing with a backoff factor 2), if the response code was one of the before mentioned codes.