### PR TITLE
lat,lon is required for closing windows.

### DIFF
--- a/docs/vehicle/commands/windows.md
+++ b/docs/vehicle/commands/windows.md
@@ -4,13 +4,17 @@
 
 Controls the windows. Will vent or close all windows simultaneously.
 
+`lat` and `lon` values must be near the current location of the car for
+`close` operation to succeed.  For `vent`, the `lat` and `lon` values are
+ignored, and may both be `0` (which has been observed from the app itself).
+
 ### Parameters
 
 | Parameter | Example | Description                                                                 |
 | :-------- | :------ | :-------------------------------------------------------------------------- |
 | command   | close   | What action to take with the windows. Allows the values `vent` and `close`. |
-| lat       | 0       | Seems to not care what this is, 0 is the only value sent by the app.        |
-| lon       | 0       | Seems to not care what this is, 0 is the only value sent by the app.        |
+| lat       | 0       | Your current latitude.  See Notes above.                                    |
+| lon       | 0       | Your current longitude.  See Notes above.                                   |
 
 ### Response
 


### PR DESCRIPTION
At least, on mine, I get the `too_far_from_vehicle` error with 0,0,
but my windows roll up if I give it the vehicle's location.