### PR TITLE
Update to vehiclestate.md with status for open/closed frunk and trunk

### DIFF
--- a/docs/vehicle/state/vehiclestate.md
+++ b/docs/vehicle/state/vehiclestate.md
@@ -59,3 +59,15 @@ Returns the vehicle's physical state, such as which doors are open.
 | 3     | Charging Screen |
 | 7     | Sentry Mode     |
 | 8     | Dog Mode        |
+
+### Trunk (rt)
+| State | Description |
+|-------|-------------|
+| 0     | Closed      |
+| 32    | Open        |
+
+### Frunk (ft)
+| State | Description |
+|-------|-------------|
+| 0     | Closed      |
+| 16    | Open        |

--- a/docs/vehicle/state/vehiclestate.md
+++ b/docs/vehicle/state/vehiclestate.md
@@ -60,6 +60,10 @@ Returns the vehicle's physical state, such as which doors are open.
 | 7     | Sentry Mode     |
 | 8     | Dog Mode        |
 
+
+For both Trunk (rt) and the Frunk (ft) argument, you should (as the official Tesla App) 
+interprete a zero (0) as closed, and a non-zero as open:
+
 ### Trunk (rt)
 | State | Description |
 |-------|-------------|


### PR DESCRIPTION
After testing on my Tesla Model LR Dual Motor in Norway, the status for open/closed frunk and trunk is defined by the elements ft and rt