### PR TITLE
Use a single BASE_URI

### DIFF
--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -2,7 +2,7 @@ module TeslaApi
   class Client
     attr_reader :api, :email, :access_token, :access_token_expires_at, :refresh_token, :client_id, :client_secret
 
-    BASE_URI = 'https://owner-api.teslamotors.com/api/1'
+    BASE_URI = 'https://owner-api.teslamotors.com'
 
     def initialize(
         email: nil,
@@ -23,7 +23,7 @@ module TeslaApi
       @refresh_token = refresh_token
 
       @api = Faraday.new(
-        BASE_URI,
+        BASE_URI + '/api/1',
         headers: { 'User-Agent' => "github.com/timdorr/tesla-api v:#{VERSION}" }
       ) do |conn|
         conn.request :json

--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -36,7 +36,7 @@ module TeslaApi
 
     def refresh_access_token
       response = api.post(
-        'https://owner-api.teslamotors.com/oauth/token',
+        BASE_URI + '/oauth/token',
         {
           grant_type: 'refresh_token',
           client_id: client_id,
@@ -54,7 +54,7 @@ module TeslaApi
 
     def login!(password)
       response = api.post(
-        'https://owner-api.teslamotors.com/oauth/token',
+        BASE_URI + '/oauth/token',
         {
           grant_type: 'password',
           client_id: client_id,

--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -35,13 +35,13 @@ module TeslaApi
     end
 
     def refresh_access_token
-      response = @api.post(
+      response = api.post(
         BASE_URI + '/oauth/token',
         {
           grant_type: 'refresh_token',
-          client_id: @client_id,
-          client_secret: @client_secret,
-          refresh_token: @refresh_token
+          client_id: client_id,
+          client_secret: client_secret,
+          refresh_token: refresh_token
         }
       ).body
 
@@ -53,13 +53,13 @@ module TeslaApi
     end
 
     def login!(password)
-      response = @api.post(
+      response = api.post(
         BASE_URI + '/oauth/token',
         {
           grant_type: 'password',
-          client_id: @client_id,
-          client_secret: @client_secret,
-          email: @email,
+          client_id: client_id,
+          client_secret: client_secret,
+          email: email,
           password: password
         }
       ).body


### PR DESCRIPTION
This removes duplicate definitions of the base URL as part of the URLs the client needs to hit. This makes it easier to configure. It's not just more DRY code I actually need to change the URI to a mock API.

Why is this needed?
Normally you wouldn't change a constant (duh!), however in my case I need to remove the constant and reset it (effectively overriding it) to allow me to test this gem in combination with a mock API that we're developing (as a sandbox, which doesn't require you to have Tesla's to develop something and you can't break any Tesla infrastructure). It's our intention as it becomes a bit nicer code that we open source this mock API so people can test against that. We need this PR for that reason.

Unsetting the const and then overriding it is fine with me, but feel free to suggest another way to achieve the ability to override the BASE_URI if that suits you better.

The last commit which adds (for instance) `@api` is technically not needed but it bypasses the getter that is created by `attr_reader :api`. You might consider it an improvement, but it's fine if you leave that as is.