### PR TITLE
Add `base_uri` as argument in the contructor

### DIFF
--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -11,9 +11,11 @@ module TeslaApi
         refresh_token: nil,
         client_id: ENV['TESLA_CLIENT_ID'],
         client_secret: ENV['TESLA_CLIENT_SECRET'],
-        retry_options: nil
+        retry_options: nil,
+        base_uri: nil
     )
       @email = email
+      @base_uri = base_uri || BASE_URI
 
       @client_id = client_id
       @client_secret = client_secret
@@ -23,7 +25,7 @@ module TeslaApi
       @refresh_token = refresh_token
 
       @api = Faraday.new(
-        BASE_URI + '/api/1',
+        @base_uri + '/api/1',
         headers: { 'User-Agent' => "github.com/timdorr/tesla-api v:#{VERSION}" }
       ) do |conn|
         conn.request :json
@@ -36,7 +38,7 @@ module TeslaApi
 
     def refresh_access_token
       response = api.post(
-        BASE_URI + '/oauth/token',
+        @base_uri + '/oauth/token',
         {
           grant_type: 'refresh_token',
           client_id: client_id,
@@ -54,7 +56,7 @@ module TeslaApi
 
     def login!(password)
       response = api.post(
-        BASE_URI + '/oauth/token',
+        @base_uri + '/oauth/token',
         {
           grant_type: 'password',
           client_id: client_id,


### PR DESCRIPTION
This is the follow up pull request after @timdorr's [comment](https://github.com/timdorr/tesla-api/pull/180#issuecomment-603592250) in #180. This is our use case as mentioned before:

We have a Ruby application which talks to the Tesla API, unfortunately not everyone in the team has a Tesla to test our app with.

That’s why we created an internal mocking server that mimics the Tesla api (to some extend).

Some users in our system connect to a mock backend and some users use the official Tesla end point, all in one codebase, at the same time. That’s why the base URI needs to be dynamic for us.
  
With this change you can initialize a Api connection with another `base_uri` in the following way:

```ruby
mocked_client = TeslaApi::Client.new(base_uri: "http://localhost/mock")
mocked_client.vehicles # connections to mocked api


regular_client = TeslaApi::Client.new
regular_client.vehicles # connections to real api
```
