### PR TITLE
Charge limit only allows integers

### DIFF
--- a/lib/tesla_api/vehicle.rb
+++ b/lib/tesla_api/vehicle.rb
@@ -94,7 +94,7 @@ module TeslaApi
     end
 
     def set_charge_limit(percent)
-      command('set_charge_limit', body: {percent: percent})['response']
+      command('set_charge_limit', body: {percent: percent.to_i})['response']
     end
 
     def charge_start


### PR DESCRIPTION
If you use a float it will set the charge limit to 50%