### PR TITLE
Set stream protocol to HTTP 1.1

### DIFF
--- a/lib/tesla_api/stream.rb
+++ b/lib/tesla_api/stream.rb
@@ -1,8 +1,8 @@
 module TeslaApi
   module Stream
-    def stream(&receiver)
+    def stream(endpoint: streaming_endpoint, &receiver)
       Async do |task|
-        Async::WebSocket::Client.connect(streaming_endpoint) do |connection|
+        Async::WebSocket::Client.connect(endpoint) do |connection|
           on_timeout = ->(subtask) do
             subtask.sleep TIMEOUT
             task.stop
@@ -42,13 +42,13 @@ module TeslaApi
       end
     end
 
-    private
-
-    TIMEOUT = 30
-
     def streaming_endpoint
       Async::HTTP::Endpoint.parse(streaming_endpoint_url, alpn_protocols: Async::HTTP::Protocol::HTTP11.names)
     end
+
+    private
+
+    TIMEOUT = 30
 
     def streaming_endpoint_url
       'wss://streaming.vn.teslamotors.com/streaming/'

--- a/lib/tesla_api/stream.rb
+++ b/lib/tesla_api/stream.rb
@@ -1,6 +1,14 @@
 module TeslaApi
   module Stream
-    def stream(endpoint: streaming_endpoint, &receiver)
+    def self.streaming_endpoint_url
+      'wss://streaming.vn.teslamotors.com/streaming/'
+    end
+
+    def self.streaming_endpoint
+      Async::HTTP::Endpoint.parse(streaming_endpoint_url, alpn_protocols: Async::HTTP::Protocol::HTTP11.names)
+    end
+
+    def stream(endpoint: Stream.streaming_endpoint, &receiver)
       Async do |task|
         Async::WebSocket::Client.connect(endpoint) do |connection|
           on_timeout = ->(subtask) do
@@ -42,17 +50,9 @@ module TeslaApi
       end
     end
 
-    def streaming_endpoint
-      Async::HTTP::Endpoint.parse(streaming_endpoint_url, alpn_protocols: Async::HTTP::Protocol::HTTP11.names)
-    end
-
     private
 
     TIMEOUT = 30
-
-    def streaming_endpoint_url
-      'wss://streaming.vn.teslamotors.com/streaming/'
-    end
 
     def streaming_connect_message
       {

--- a/lib/tesla_api/stream.rb
+++ b/lib/tesla_api/stream.rb
@@ -47,7 +47,7 @@ module TeslaApi
     TIMEOUT = 30
 
     def streaming_endpoint
-      Async::HTTP::Endpoint.parse(streaming_endpoint_url)
+      Async::HTTP::Endpoint.parse(streaming_endpoint_url, alpn_protocols: Async::HTTP::Protocol::HTTP11.names)
     end
 
     def streaming_endpoint_url


### PR DESCRIPTION
Fixes issue #191 

I also added a change to allow the endpoint to be configurable – this would allow me to proxy streams as well as the REST API.