### PR TITLE
Update Autopilot & Hardware codes

### DIFF
--- a/docs/vehicle/optioncodes.md
+++ b/docs/vehicle/optioncodes.md
@@ -45,7 +45,6 @@ return a generic set of codes related to a Model 3.
 | AF02 | HEPA Filter | | 
 | AH00 | No Accessory Hitch | | 
 | APBS | Autopilot | Model 3 Autopilot |
-| APE1 | Enhanced Autopilot | | 
 | APF0 | Autopilot Firmware 2.0 Base | | 
 | APF1 | Autopilot Firmware 2.0 Enhanced | |  
 | APF2 | Full Self-Driving Capability | |

--- a/docs/vehicle/optioncodes.md
+++ b/docs/vehicle/optioncodes.md
@@ -44,16 +44,15 @@ return a generic set of codes related to a Model 3.
 | AF00 | No HEPA Filter | Standard air filter, no air ionizer | 
 | AF02 | HEPA Filter | | 
 | AH00 | No Accessory Hitch | | 
+| APBS | Autopilot | Model 3 Autopilot |
 | APE1 | Enhanced Autopilot | | 
 | APF0 | Autopilot Firmware 2.0 Base | | 
 | APF1 | Autopilot Firmware 2.0 Enhanced | |  
-| APH0 | Non Autopilot | | 
-| APH1 | Autopilot 1.0 | | 
-| APH2 | Autopilot 2.0 | | 
-| APBS | Autopilot | Model 3 Autopilot |
 | APF2 | Full Self-Driving Capability | |
-| APH3 | Autopilot 2.5 Hardware | |
-| APH4 | Autopilot 3.0 Hardware | Full Self-Driving Computer | 
+| APH1 | Hardware 1.0 | | 
+| APH2 | Hardware 2.0 | | 
+| APH3 | Hardware 2.5 | | 
+| APH4 | Hardware 3.0 | | 
 | APPA | Autopilot 1.0 Hardware | | 
 | APPB | Enhanced Autopilot | | 
 | AU00 | No Audio Package | | 

--- a/docs/vehicle/optioncodes.md
+++ b/docs/vehicle/optioncodes.md
@@ -48,8 +48,9 @@ return a generic set of codes related to a Model 3.
 | APF0 | Autopilot Firmware 2.0 Base | | 
 | APF1 | Autopilot Firmware 2.0 Enhanced | | 
 | APF2 | Full Self-Driving Capability | | 
-| APH0 | Autopilot 2.0 Hardware | | 
-| APH2 | Autopilot 2.0 Hardware | | 
+| APH0 | Non Autopilot | | 
+| APH1 | Autopilot 1.0 | | 
+| APH2 | Autopilot 2.0 | | 
 | APBS | Autopilot | Model 3 Autopilot |
 | APF2 | Full Self-Driving Capability | |
 | APH3 | Autopilot 2.5 Hardware | |

--- a/docs/vehicle/optioncodes.md
+++ b/docs/vehicle/optioncodes.md
@@ -46,8 +46,7 @@ return a generic set of codes related to a Model 3.
 | AH00 | No Accessory Hitch | | 
 | APE1 | Enhanced Autopilot | | 
 | APF0 | Autopilot Firmware 2.0 Base | | 
-| APF1 | Autopilot Firmware 2.0 Enhanced | | 
-| APF2 | Full Self-Driving Capability | | 
+| APF1 | Autopilot Firmware 2.0 Enhanced | |  
 | APH0 | Non Autopilot | | 
 | APH1 | Autopilot 1.0 | | 
 | APH2 | Autopilot 2.0 | | 

--- a/docs/vehicle/optioncodes.md
+++ b/docs/vehicle/optioncodes.md
@@ -53,8 +53,6 @@ return a generic set of codes related to a Model 3.
 | APH2 | Hardware 2.0 | | 
 | APH3 | Hardware 2.5 | | 
 | APH4 | Hardware 3.0 | | 
-| APPA | Autopilot 1.0 Hardware | | 
-| APPB | Enhanced Autopilot | | 
 | AU00 | No Audio Package | | 
 | AU01 | Ultra High Fidelity Sound | | 
 | AU3P | Sound Studio Package | Premium audio package |


### PR DESCRIPTION
I removed `hardware` keyword because hardware is a totally different thing; You can have Autopilot 2 with HW2, HW2.5 or HW3.0