### PR TITLE
Add note about setting User-Agent during auth

### DIFF
--- a/docs/api-basics/authentication.md
+++ b/docs/api-basics/authentication.md
@@ -8,6 +8,8 @@ description: The authentication process for the Tesla API
 >
 > Tesla has deprecated the `/oauth/token` endpoint in favor of using `auth.tesla.com`. I'm working on updating the documentation as soon as possible. This documentation is still missing handling for MFA users. Feel free to discuss this in [issue #260](https://github.com/timdorr/tesla-api/issues/260).
 
+> Avoid setting your `User-Agent` to one that looks like a browser.  If Tesla detects this the first step can result in the request responding with a page of JS which hits a /TSPD/ endpoint instead of returning the auth form.
+
 Tesla uses a separate SSO service (auth.tesla.com) for authentication across their app and website. This service is designed around a browser-based flow using OAuth 2.0, but also appears to have support for Open ID Connect. This supports both obtaining an access token and refreshing it as it expires.
 
 ## Logging in

--- a/docs/api-basics/authentication.md
+++ b/docs/api-basics/authentication.md
@@ -8,8 +8,6 @@ description: The authentication process for the Tesla API
 >
 > Tesla has deprecated the `/oauth/token` endpoint in favor of using `auth.tesla.com`. I'm working on updating the documentation as soon as possible. This documentation is still missing handling for MFA users. Feel free to discuss this in [issue #260](https://github.com/timdorr/tesla-api/issues/260).
 
-> Avoid setting your `User-Agent` to one that looks like a browser.  If Tesla detects this the first step can result in the request responding with a page of JS which hits a /TSPD/ endpoint instead of returning the auth form.
-
 Tesla uses a separate SSO service (auth.tesla.com) for authentication across their app and website. This service is designed around a browser-based flow using OAuth 2.0, but also appears to have support for Open ID Connect. This supports both obtaining an access token and refreshing it as it expires.
 
 ## Logging in
@@ -24,6 +22,8 @@ code_challenge = Base64.urlsafe_encode64(Digest::SHA256.hexdigest(code_verifier)
 ```
 
 You will also need a stable `state` value for requests, which is a random string of any length.
+
+Avoid setting a `User-Agent` header that looks like a browser (such as Chrome or Safari). The SSO service has protections in place that will require executing JavaScript if a browser-like user agent is detected. 
 
 #### GET `https://auth.tesla.com/oauth2/v3/authorize`
 


### PR DESCRIPTION
After some testing I noticed Tesla's new Auth0 endpoints would sometimes return a page of obfuscated javascript.  Watching the requests from the app I noticed the JS evaluated would result in 1-3 requests to `https://auth.tesla.com/TSPD/`.  This would only happen if `User-Agent` was set to a UA that looked like a browser.  After changing it to something obscure that identified the application it worked fine.

<img width="1912" alt="Screen Shot 2021-01-31 at 7 27 03 PM" src="https://user-images.githubusercontent.com/43329/106412241-1d55c200-63fc-11eb-80b6-c85c15bf2578.png">
