### PR TITLE
Fix the timeouts

### DIFF
--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -5,7 +5,7 @@ module TeslaApi
     BASE_URI = "https://owner-api.teslamotors.com"
     SSO_URI = "https://auth.tesla.com"
 
-    DEFAULT_HEADERS = {"User-Agent" => "github.com/timdorr/tesla-api v:#{VERSION}"}
+    DEFAULT_HEADERS = {"X-User-Agent" => "github.com/timdorr/tesla-api v:#{VERSION}"}
 
     def initialize(
       email: nil,


### PR DESCRIPTION
We were getting timeouts on the POST to `/oauth2/v3/token` with tesla_api version 3.1.0.

For [us](https://Stekker.app) this resolves them consistently. We tried many different things, but this is the only solution that works all the time. We verified it with multiple real Tesla accounts. It also doesn't seem to matter from which IP address we perform our request.

I don't really like it that we can't simply specify the user agent in the canonical way, but this seems to me to be the next best way. Also, it's better than not being able to use the API at all (or at least, getting a token, that is). If someone finds a better way, hopefully this is a good departure point.

Until a solution is merged, you can use our fork if you like, as follows:
```
git_source(:github) { |repo| "https://github.com/#{repo}.git" }

gem "tesla_api", github: "stekker/tesla-api", branch: "fix-timeouts"
```