### PR TITLE
Update optioncodes.md

### DIFF
--- a/docs/vehicle/optioncodes.md
+++ b/docs/vehicle/optioncodes.md
@@ -153,8 +153,8 @@ return a generic set of codes related to a Model 3.
 | HL31   | Head Lamp                                                | Model 3 Uplevel Headlamps                                 |
 | HP00   | No HPWC Ordered                                          |                                                           |
 | HP01   | HPWC Ordered                                             |                                                           |
-| IBB0   | All Black Interior                                       | Model 3 Interior (Left Hand Drive)                        |
-| IBB1   | All Black Interior                                       | Model 3 Interior (Right Hand Drive)                       |
+| IBB0   | All Black Interior                                       | Model 3 Old Door Trim                                     |
+| IBB1   | All Black Interior                                       | Model 3 New Door Trim (Since Q1 2021)                     |
 | ID3W   | Wood Decor                                               | Model 3                                                   |
 | IDBA   | Dark Ash Wood Decor                                      |                                                           |
 | IDBO   | Figured Ash Wood Decor                                   |                                                           |
@@ -166,8 +166,8 @@ return a generic set of codes related to a Model 3.
 | IDLW   | Lacewood Decor                                           |                                                           |
 | IDPB   | Piano Black Decor                                        |                                                           |
 | IN3BB  | All Black Partial Premium Interior                       |                                                           |
-| IBW0   | Black and White Interior                                 | Model 3 Interior (Left Hand Drive)                        |
-| IBW1   | Black and White Interior                                 | Model 3 Interior (Right Hand Drive)                       |
+| IBW0   | Black and White Interior                                 | Model 3 Old Door Trim                                     |
+| IBW1   | Black and White Interior                                 | Model 3 New Door Trim (Since Q1 2021)                     |
 | IN3BW  | Black and White Interior                                 | Model 3 Interior                                          |
 | IN3PB  | All Black Premium Interior                               | Model 3 Interior                                          |
 | IN3PW  | All White Premium Interior                               | Model 3 Interior                                          |


### PR DESCRIPTION
German Tesla Community is tracking deliveries and invoices of SR+ vehicles. For europe it seems, that prior to April 9th the option code for door trim was IBB0/IBW0. After 9th all customers received their invoice with IBB1/IBW1. At the same day Tesla also changed the online configurator to show the new door trims (wooden/white panel in door).
Source: https://tff-forum.de/t/model-3-sr-bestellung-und-auslieferung-q2-2021/108887/2368?u=stadlix