### PR TITLE
Update vehicles.md

### DIFF
--- a/docs/api-basics/vehicles.md
+++ b/docs/api-basics/vehicles.md
@@ -14,7 +14,7 @@ For the state and command APIs, you should be using the `id` field. If your JSON
 
 ## GET `/api/1/vehicles`
 
-Retrieve a list of your owned vehicles (includes vehicles not yet shipped!)
+Retrieve a list of your owned vehicles.
 
 ### Request parameters
 


### PR DESCRIPTION
Removed text snippet about cars not yet shipped.
Current API doesn't include any car-references until the vehicle has been delivered. Instead an empty response is the only output.