### PR TITLE
Use SSO access_token directly instead of exchanging it

### DIFF
--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -53,8 +53,9 @@ module TeslaApi
         }
       ).body
 
-      @refresh_token = response["refresh_token"]
-      exchange_sso_access_token(response["access_token"])
+      @refresh_token = response['refresh_token']
+      @access_token = response['access_token']
+      @access_token_expires_at = (Time.now + response['expires_in']).to_datetime
     end
 
     def login!(password, mfa_code: nil)

--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -53,9 +53,9 @@ module TeslaApi
         }
       ).body
 
-      @refresh_token = response['refresh_token']
-      @access_token = response['access_token']
-      @access_token_expires_at = (Time.now + response['expires_in']).to_datetime
+      @refresh_token = response["refresh_token"]
+      @access_token = response["access_token"]
+      @access_token_expires_at = (Time.now + response["expires_in"]).to_datetime
     end
 
     def login!(password, mfa_code: nil)

--- a/spec/cassettes/client-refresh.yml
+++ b/spec/cassettes/client-refresh.yml
@@ -54,58 +54,6 @@ http_interactions:
           - keep-alive
       body:
         encoding: UTF-8
-        string: '{"access_token":"acess","refresh_token":"<TESLA_REFRESH_TOKEN>","id_token":"id","expires_in":300,"token_type":"Bearer"}'
+        string: '{"access_token":"acess","refresh_token":"<TESLA_REFRESH_TOKEN>","id_token":"id","expires_in":28800,"token_type":"Bearer"}'
     recorded_at: Sat, 30 Jan 2021 15:18:43 GMT
-  - request:
-      method: post
-      uri: https://owner-api.teslamotors.com/oauth/token
-      body:
-        encoding: UTF-8
-        string: '{"grant_type":"urn:ietf:params:oauth:grant-type:jwt-bearer","client_id":"<TESLA_CLIENT_ID>","client_secret":"<TESLA_CLIENT_SECRET>"}'
-      headers:
-        User-Agent:
-          - github.com/timdorr/tesla-api v:3.0.7
-        Authorization:
-          - Bearer bear
-        Content-Type:
-          - application/json
-        Accept-Encoding:
-          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-        Accept:
-          - '*/*'
-    response:
-      status:
-        code: 200
-        message: OK
-      headers:
-        Date:
-          - Sat, 30 Jan 2021 15:18:44 GMT
-        Content-Type:
-          - application/json; charset=utf-8
-        Transfer-Encoding:
-          - chunked
-        Connection:
-          - keep-alive
-        Vary:
-          - Accept-Encoding
-        X-Frame-Options:
-          - SAMEORIGIN
-        X-Xss-Protection:
-          - 1; mode=block
-        X-Content-Type-Options:
-          - nosniff
-        Etag:
-          - W/"85c5baa66d3db433982e5744ccc1e96e"
-        Cache-Control:
-          - max-age=0, private, must-revalidate
-        X-Request-Id:
-          - 2f0ad7f617da468d211594930c0e88d52f0ad7f617da468d211594930c0e88d5
-        X-Runtime:
-          - '0.301686'
-        Strict-Transport-Security:
-          - max-age=15724800; includeSubDomains
-      body:
-        encoding: ASCII-8BIT
-        string: '{"access_token":"qts-deadbeef","token_type":"bearer","expires_in":3888000,"refresh_token":"yes","created_at":1612019924}'
-    recorded_at: Sat, 30 Jan 2021 15:18:44 GMT
 recorded_with: VCR 6.0.0

--- a/spec/lib/tesla_api/client_spec.rb
+++ b/spec/lib/tesla_api/client_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe TeslaApi::Client do
     subject(:tesla_api) {
       TeslaApi::Client.new(
         access_token: access_token,
-        access_token_expires_at: DateTime.now + 1,
+        access_token_expires_at: (Time.now + 3600).to_datetime,
         refresh_token: refresh_token
       )
     }
@@ -109,8 +109,11 @@ RSpec.describe TeslaApi::Client do
       ]
     } do
       it "refreshes the access token" do
+        access_token_expires_at = tesla_api.access_token_expires_at
+
         tesla_api.refresh_access_token
         expect(tesla_api.access_token).not_to eq(access_token)
+        expect(tesla_api.access_token_expires_at).to be > access_token_expires_at
       end
     end
   end


### PR DESCRIPTION
We noticed that exchanging the SSO token for an `access_token` in the `refresh_access_token` method does not work anymore (and received a 401 when trying to POST to https://owner-api.teslamotors.com/oauth/token).

However, it works perfectly fine if the returned `access_token` is used directly. The only downside is: its only valid for 8 hours (28800 seconds).