### PR TITLE
Update Authentication & Climate Documentation 📚

### DIFF
--- a/docs/api-basics/authentication.md
+++ b/docs/api-basics/authentication.md
@@ -136,7 +136,7 @@ This is a standard [OAuth 2.0 Authorization Code exchange](https://oauth.net/2/g
 
 ## Making requests
 
-Requests are made using the ``access_token`` provided with the response. It is treated as an [OAuth 2.0 Bearer Token](https://oauth.net/2/bearer-tokens/) and expires every eight hours. This token is passed along in an Authorization header with all future requests:
+Requests are made using the `access_token` provided with the response. It is treated as an [OAuth 2.0 Bearer Token](https://oauth.net/2/bearer-tokens/) and expires every eight hours. This token is passed along in an Authorization header with all future requests:
 
 ```http
 Authorization: Bearer {access_token}

--- a/docs/vehicle/commands/climate.md
+++ b/docs/vehicle/commands/climate.md
@@ -117,3 +117,59 @@ Turn steering wheel heater on or off.
   "result": true
 }
 ```
+
+## POST `/api/1/vehicles/{id}/command/set_bioweapon_mode`
+
+Enable or disable Bioweapon Defense Mode.
+
+### Request
+
+This endpoint requires json in the post body, with the singular parameter ``on`` which is either ``true`` or ``false``.
+This endpoint will respond with the ``result`` as ``true`` even with no parameters or body specified.
+
+```json
+{
+  "on" : "true"
+}
+```
+
+### Response
+
+```json
+{
+  "reason": "",
+  "result": true
+}
+```
+
+## POST `/api/1/vehicles/{id}/command/set_climate_keeper_mode`
+
+Set the Climate Keeper mode.
+
+### Request
+
+This endpoint requires json in the post body, with the singular parameter ``climate_keeper_mode`` and a number as the value. Those map to the values below.
+
+| Number | Mode         |
+| :----- | :----------- |
+| 0      | Off          |
+| 1      | On - Default |
+| 2      | Dog Mode     |
+| 3      | Camp Mode    |
+
+### Example
+
+```json
+{
+  "climate_keeper_mode" : 0
+}
+```
+
+### Response
+
+```json
+{
+  "reason": "",
+  "result": true
+}
+```

--- a/docs/vehicle/commands/climate.md
+++ b/docs/vehicle/commands/climate.md
@@ -147,7 +147,7 @@ Set the Climate Keeper mode.
 
 ### Request
 
-This endpoint requires json in the post body, with the singular parameter ``climate_keeper_mode`` and a number as the value. Those map to the values below.
+This endpoint requires json in the post body, with the singular parameter `climate_keeper_mode` and a number as the value. Those map to the values below.
 
 | Number | Mode         |
 | :----- | :----------- |

--- a/docs/vehicle/commands/climate.md
+++ b/docs/vehicle/commands/climate.md
@@ -131,6 +131,7 @@ This endpoint will respond with the `result` as `true` even with no parameters o
 {
   "on": "true"
 }
+```
 
 ### Response
 

--- a/docs/vehicle/commands/climate.md
+++ b/docs/vehicle/commands/climate.md
@@ -124,14 +124,13 @@ Enable or disable Bioweapon Defense Mode.
 
 ### Request
 
-This endpoint requires json in the post body, with the singular parameter ``on`` which is either ``true`` or ``false``.
-This endpoint will respond with the ``result`` as ``true`` even with no parameters or body specified.
+This endpoint requires json in the post body, with the singular parameter `on` which is either `true` or `false`.
+This endpoint will respond with the `result` as `true` even with no parameters or body specified.
 
 ```json
 {
-  "on" : "true"
+  "on": "true"
 }
-```
 
 ### Response
 

--- a/docs/vehicle/commands/climate.md
+++ b/docs/vehicle/commands/climate.md
@@ -161,7 +161,7 @@ This endpoint requires json in the post body, with the singular parameter ``clim
 
 ```json
 {
-  "climate_keeper_mode" : 0
+  "climate_keeper_mode": 0
 }
 ```
 

--- a/docs/vehicle/optioncodes.md
+++ b/docs/vehicle/optioncodes.md
@@ -353,6 +353,7 @@ return a generic set of codes related to a Model 3.
 | MTS08  | Performance                                              | Model S                                                   |
 | MTS09  | Plaid+                                                   | Model S Refresh 2021                                      |
 | MTS10  | Long Range                                               | Model S Refresh 2021                                      |
+| MTS13  | Long Range                                               | Model S Refresh 2022                                      |
 | MTS11  | Plaid                                                    | Model S Refresh 2021                                      |
 | MTS14  | Plaid                                                    | Model S Refresh 2022                                      |
 | MTX01  | Standard Range                                           | Model X                                                   |


### PR DESCRIPTION
Update documentation to fit the API changes regarding the OAuth bearer token, and remove step four, as it has been depracted and add documentation for the ``set_bioweapon_mode`` and ``set_climate_keeper_mode`` endpoints.