### PR TITLE
Removed deprecated authentication details

### DIFF
--- a/docs/api-basics/authentication.md
+++ b/docs/api-basics/authentication.md
@@ -136,7 +136,7 @@ This is a standard [OAuth 2.0 Authorization Code exchange](https://oauth.net/2/g
 
 ## Making requests
 
-Requests are made using the `access_token` provided with the above response. It is treated as an [OAuth 2.0 Bearer Token](https://oauth.net/2/bearer-tokens/) and expires every eight hours. Owner API `/auth/token` should not longer be used for SSO to Owner API access token exchange and can be used directly with Owner API end points. The `access_token` is to be passed in an Authorization header with all requests to Owner API:
+Requests are made using the `access_token` provided with the response. It is treated as an [OAuth 2.0 Bearer Token](https://oauth.net/2/bearer-tokens/) and expires every eight hours. This token is passed along in an Authorization header with all future requests:
 
 ```http
 Authorization: Bearer {access_token}

--- a/docs/api-basics/authentication.md
+++ b/docs/api-basics/authentication.md
@@ -136,7 +136,7 @@ This is a standard [OAuth 2.0 Authorization Code exchange](https://oauth.net/2/g
 
 ## Making requests
 
-Requests are made using the `access_token` provided with the response. It is treated as an [OAuth 2.0 Bearer Token](https://oauth.net/2/bearer-tokens/) and expires every eight hours. This token is passed along in an Authorization header with all future requests:
+Requests are made using the `access_token` provided with the above response. It is treated as an [OAuth 2.0 Bearer Token](https://oauth.net/2/bearer-tokens/) and expires every eight hours. Owner API `/auth/token` should not longer be used for SSO to Owner API access token exchange and can be used directly with Owner API end points. The `access_token` is to be passed in an Authorization header with all requests to Owner API:
 
 ```http
 Authorization: Bearer {access_token}
@@ -146,13 +146,9 @@ Authorization: Bearer {access_token}
 
 #### POST `https://auth.tesla.com/oauth2/v3/token`
 
-This uses the SSO `refresh_token` from Step 3 above to do an [OAuth 2.0 Refresh Token Grant](https://oauth.net/2/grant-types/refresh-token/). _This does not work with the `refresh_token` provided by the Owner API._ Those have no use currently and should be discarded.
-
-This refreshed access token can be used with the Owner API to obtain a new access token for that service using the exact same request as Step 4 above.
+This uses the SSO `refresh_token` from Step 3 above to do an [OAuth 2.0 Refresh Token Grant](https://oauth.net/2/grant-types/refresh-token/). The refreshed access token is to be used directly with the Owner API as a bearer token as per the above _Making requests_ section. 
 
 This endpoint uses JSON for the request and response bodies.
-
-Should your Owner API token begin with `cn-` you should POST to `auth.tesla.cn` Tesla SSO service to have it refresh. Owner API tokens starting with `qts-` are to be refreshed using `auth.tesla.com`
 
 ##### Request parameters
 

--- a/docs/api-basics/authentication.md
+++ b/docs/api-basics/authentication.md
@@ -146,7 +146,7 @@ Authorization: Bearer {access_token}
 
 #### POST `https://auth.tesla.com/oauth2/v3/token`
 
-This uses the SSO `refresh_token` from Step 3 above to do an [OAuth 2.0 Refresh Token Grant](https://oauth.net/2/grant-types/refresh-token/). The refreshed access token is to be used directly with the Owner API as a bearer token as per the above _Making requests_ section. 
+This uses the SSO `refresh_token` from Step 3 above to do an [OAuth 2.0 Refresh Token Grant](https://oauth.net/2/grant-types/refresh-token/). The refreshed access token is to be used directly with the Owner API as a bearer token as per the above _Making requests_ section.
 
 This endpoint uses JSON for the request and response bodies.
 


### PR DESCRIPTION
Some details around access token use and refreshing are no longer valid including:
- removal of reference to Step 4 which is missing
- removal of reference to access tokens with region specific prefixes which are no longer relevant
- removal of comment about using Owner API to get a new access token which is no longer required
- calling out that SSO to Owner API access token exchange is no longer required for clarity