### PR TITLE
Solar energy state updates

### DIFF
--- a/docs/energy/state.md
+++ b/docs/energy/state.md
@@ -4,10 +4,104 @@ These endpoints are not yet documented.
 
 | Cmd | Endpoint                |
 | :-- | :---------------------- |
-| GET | `live_status`           |
-| GET | `site_info`             |
 | GET | `tariff_rate`           |
 | GET | `tariff_rates`          |
 | GET | `savings_forecast`      |
 | GET | `backup_time_remaining` |
 | GET | `programs`              |
+
+## GET `/api/1/energy_sites/{site_id}/live_status`
+
+Retrieves current system information (e.g. solar production, grid export/import, home consumption, etc.).
+
+### Response for solar panel system without powerwalls
+
+```json
+{
+    "response": {
+        "solar_power": 7720,
+        "energy_left": 0,
+        "total_pack_energy": 1,
+        "percentage_charged": 0,
+        "battery_power": 0,
+        "load_power": 4517.14990234375,
+        "grid_status": "Unknown",
+        "grid_services_active": false,
+        "grid_power": -3202.85009765625,
+        "grid_services_power": 0,
+        "generator_power": 0,
+        "island_status": "island_status_unknown",
+        "storm_mode_active": false,
+        "timestamp": "2022-07-28T17:11:27Z",
+        "wall_connectors": null
+    }
+}
+```
+
+## GET `/api/1/energy_sites/{site_id}/site_status`
+
+Retrieves general system information.
+
+### Response for solar panel system without powerwalls
+
+```json
+{
+    "response": {
+        "resource_type": "solar",
+        "asset_site_id": "47d04752-9cf1-4e76-88fb-08839a1c41c4",
+        "solar_power": 7700,
+        "solar_type": "pv_panel",
+        "sync_grid_alert_enabled": false,
+        "breaker_alert_enabled": false
+    }
+}
+```
+
+## GET `/api/1/energy_sites/{site_id}/site_info`
+
+Retrieves general system information.
+
+### Response for solar panel system without powerwalls
+
+```json
+{
+    "response": {
+        "id": "313dbc37-555c-45b1-83aa-62a4ef9ff7ac",
+        "site_number": "2252147638651575",
+        "installation_date": "2022-04-04T15:56:35-07:00",
+        "user_settings": {
+            "storm_mode_enabled": null,
+            "powerwall_onboarding_settings_set": null,
+            "sync_grid_alert_enabled": false,
+            "breaker_alert_enabled": false
+        },
+        "components": {
+            "solar": true,
+            "solar_type": "pv_panel",
+            "battery": false,
+            "grid": true,
+            "backup": false,
+            "gateway": "gateway_type_none",
+            "load_meter": true,
+            "tou_capable": false,
+            "storm_mode_capable": false,
+            "flex_energy_request_capable": false,
+            "car_charging_data_supported": false,
+            "off_grid_vehicle_charging_reserve_supported": false,
+            "vehicle_charging_performance_view_enabled": false,
+            "vehicle_charging_solar_offset_view_enabled": false,
+            "battery_solar_offset_view_enabled": false,
+            "energy_service_self_scheduling_enabled": true,
+            "rate_plan_manager_supported": true,
+            "configurable": false,
+            "grid_services_enabled": false
+        },
+        "installation_time_zone": "America/Los_Angeles",
+        "time_zone_offset": -420,
+        "geolocation": {
+            "latitude": 32.53452700000001,
+            "longitude": -112.3463137
+        }
+    }
+}
+```

--- a/docs/energy/state.md
+++ b/docs/energy/state.md
@@ -18,23 +18,23 @@ Retrieves current system information (e.g. solar production, grid export/import,
 
 ```json
 {
-    "response": {
-        "solar_power": 7720,
-        "energy_left": 0,
-        "total_pack_energy": 1,
-        "percentage_charged": 0,
-        "battery_power": 0,
-        "load_power": 4517.14990234375,
-        "grid_status": "Unknown",
-        "grid_services_active": false,
-        "grid_power": -3202.85009765625,
-        "grid_services_power": 0,
-        "generator_power": 0,
-        "island_status": "island_status_unknown",
-        "storm_mode_active": false,
-        "timestamp": "2022-07-28T17:11:27Z",
-        "wall_connectors": null
-    }
+  "response": {
+    "solar_power": 7720,
+    "energy_left": 0,
+    "total_pack_energy": 1,
+    "percentage_charged": 0,
+    "battery_power": 0,
+    "load_power": 4517.14990234375,
+    "grid_status": "Unknown",
+    "grid_services_active": false,
+    "grid_power": -3202.85009765625,
+    "grid_services_power": 0,
+    "generator_power": 0,
+    "island_status": "island_status_unknown",
+    "storm_mode_active": false,
+    "timestamp": "2022-07-28T17:11:27Z",
+    "wall_connectors": null
+  }
 }
 ```
 
@@ -46,14 +46,14 @@ Retrieves general system information.
 
 ```json
 {
-    "response": {
-        "resource_type": "solar",
-        "asset_site_id": "47d04752-9cf1-4e76-88fb-08839a1c41c4",
-        "solar_power": 7700,
-        "solar_type": "pv_panel",
-        "sync_grid_alert_enabled": false,
-        "breaker_alert_enabled": false
-    }
+  "response": {
+    "resource_type": "solar",
+    "asset_site_id": "47d04752-9cf1-4e76-88fb-08839a1c41c4",
+    "solar_power": 7700,
+    "solar_type": "pv_panel",
+    "sync_grid_alert_enabled": false,
+    "breaker_alert_enabled": false
+  }
 }
 ```
 
@@ -65,43 +65,43 @@ Retrieves general system information.
 
 ```json
 {
-    "response": {
-        "id": "313dbc37-555c-45b1-83aa-62a4ef9ff7ac",
-        "site_number": "2252147638651575",
-        "installation_date": "2022-04-04T15:56:35-07:00",
-        "user_settings": {
-            "storm_mode_enabled": null,
-            "powerwall_onboarding_settings_set": null,
-            "sync_grid_alert_enabled": false,
-            "breaker_alert_enabled": false
-        },
-        "components": {
-            "solar": true,
-            "solar_type": "pv_panel",
-            "battery": false,
-            "grid": true,
-            "backup": false,
-            "gateway": "gateway_type_none",
-            "load_meter": true,
-            "tou_capable": false,
-            "storm_mode_capable": false,
-            "flex_energy_request_capable": false,
-            "car_charging_data_supported": false,
-            "off_grid_vehicle_charging_reserve_supported": false,
-            "vehicle_charging_performance_view_enabled": false,
-            "vehicle_charging_solar_offset_view_enabled": false,
-            "battery_solar_offset_view_enabled": false,
-            "energy_service_self_scheduling_enabled": true,
-            "rate_plan_manager_supported": true,
-            "configurable": false,
-            "grid_services_enabled": false
-        },
-        "installation_time_zone": "America/Los_Angeles",
-        "time_zone_offset": -420,
-        "geolocation": {
-            "latitude": 32.53452700000001,
-            "longitude": -112.3463137
-        }
+  "response": {
+    "id": "313dbc37-555c-45b1-83aa-62a4ef9ff7ac",
+    "site_number": "2252147638651575",
+    "installation_date": "2022-04-04T15:56:35-07:00",
+    "user_settings": {
+      "storm_mode_enabled": null,
+      "powerwall_onboarding_settings_set": null,
+      "sync_grid_alert_enabled": false,
+      "breaker_alert_enabled": false
+    },
+    "components": {
+      "solar": true,
+      "solar_type": "pv_panel",
+      "battery": false,
+      "grid": true,
+      "backup": false,
+      "gateway": "gateway_type_none",
+      "load_meter": true,
+      "tou_capable": false,
+      "storm_mode_capable": false,
+      "flex_energy_request_capable": false,
+      "car_charging_data_supported": false,
+      "off_grid_vehicle_charging_reserve_supported": false,
+      "vehicle_charging_performance_view_enabled": false,
+      "vehicle_charging_solar_offset_view_enabled": false,
+      "battery_solar_offset_view_enabled": false,
+      "energy_service_self_scheduling_enabled": true,
+      "rate_plan_manager_supported": true,
+      "configurable": false,
+      "grid_services_enabled": false
+    },
+    "installation_time_zone": "America/Los_Angeles",
+    "time_zone_offset": -420,
+    "geolocation": {
+      "latitude": 32.53452700000001,
+      "longitude": -112.3463137
     }
+  }
 }
 ```


### PR DESCRIPTION
I have a Tesla solar system (11.2 kW) with a single Tesla inverter (7.6 kW) and no powerwalls. I do have the Neurio energy monitoring device installed which provides grid export/import (measured) and home consumption (calculated) in the Tesla app. I noticed there wasn't any documentation for some of the endpoints so I figured I'd add them. I specified the response is for a solar panel system without poweralls. Some of the unique data to my system was replaced or obfuscated but the formatting was not changed.