### PR TITLE
Remove dependency to faraday_middleware

### DIFF
--- a/lib/tesla_api.rb
+++ b/lib/tesla_api.rb
@@ -2,7 +2,7 @@ require "date"
 require "base64"
 
 require "faraday"
-require "faraday_middleware"
+require "faraday/retry"
 
 require "async"
 require "async/http/endpoint"

--- a/tesla_api.gemspec
+++ b/tesla_api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "async-websocket"
   spec.add_dependency "faraday"
-  spec.add_dependency "faraday_middleware"
+  spec.add_dependency "faraday-retry"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
The `faraday_middleware` gem has been deprecated. This pull request removes the dependency to it and adds `faraday-retry` as single dependency.