### PR TITLE
Update ownerapi_endpoints, document 2 endpoints, update docs 📚 

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,6 +5,7 @@
 ## API Basics
 
 - [Authentication](api-basics/authentication.md)
+- [Users](api-basics/users.md)
 - [Vehicles](api-basics/vehicles.md)
 - [Energy Products](api-basics/products.md)
 

--- a/docs/api-basics/users.md
+++ b/docs/api-basics/users.md
@@ -22,7 +22,9 @@ Get the current user's information.
 
 ## GET `/api/1/users/vault_profile`
 
-> Info: This endpoint is a mystery, it returns what appears to be base64 encoded strings. When decoded it has a bunch of jibberish and then two certificates and some readable strings, and what appears to be a hash of something.
+{% hint style='info' %}
+This endpoint is a mystery, it returns what appears to be base64 encoded strings. When decoded it has a bunch of jibberish and then two certificates and some readable strings, and what appears to be a hash of something.
+{% endhint %}
 
 ### Response
 

--- a/docs/api-basics/users.md
+++ b/docs/api-basics/users.md
@@ -4,7 +4,7 @@ description: Endpoints for getting information about the current user
 
 # Users
 
-These endpoints are provide data on the current user. 
+These endpoints provide data on the current user.
 
 ## GET `/api/1/users/me`
 

--- a/docs/api-basics/users.md
+++ b/docs/api-basics/users.md
@@ -1,8 +1,14 @@
-# User Information
+---
+description: Endpoints for getting information about the current user
+---
+
+# Users
+
+These endpoints are provide data on the current user. 
 
 ## GET `/api/1/users/me`
 
-Get your user information
+Get the current user's information.
 
 ### Response
 
@@ -14,15 +20,9 @@ Get your user information
 }
 ```
 
-<br/>
-
-# Download Vault Profile
-
-> Info: This endpoint is a mystery, it returns what appears to be base64 encoded strings. When decoded it has a bunch of jibberish and then two certificates and some readable strings, and what appears to be a hash of something.
-
 ## GET `/api/1/users/vault_profile`
 
-Download Vault Profile
+> Info: This endpoint is a mystery, it returns what appears to be base64 encoded strings. When decoded it has a bunch of jibberish and then two certificates and some readable strings, and what appears to be a hash of something.
 
 ### Response
 
@@ -32,13 +32,9 @@ Download Vault Profile
 }
 ```
 
-<br/>
-
-# Feature Config
-
 ## GET `/api/1/users/feature_config`
 
-Get the feature config.
+Get the feature configuration for the mobile app.
 
 ### Response
 

--- a/docs/user/data.md
+++ b/docs/user/data.md
@@ -1,0 +1,52 @@
+# User Information
+
+## GET `/api/1/users/me`
+
+Get your user information
+
+### Response
+
+```json
+{
+  "email": "elon@tesla.com",
+  "full_name": "Elon Musk",
+  "profile_image_url": "https://vehicle-files.prd.euw1.vn.cloud.tesla.com/profile_images/{IMG}.jpg"
+}
+```
+
+<br/>
+
+# Download Vault Profile
+
+> Info: This endpoint is a mystery, it returns what appears to be base64 encoded strings. When decoded it has a bunch of jibberish and then two certificates and some readable strings, and what appears to be a hash of something.
+
+## GET `/api/1/users/vault_profile`
+
+Download Vault Profile
+
+### Response
+
+```json
+{
+  "vault": "base64_jibberish"
+}
+```
+
+<br/>
+
+# Feature Config
+
+## GET `/api/1/users/feature_config`
+
+Get the feature config.
+
+### Response
+
+```json
+{
+  "signaling": {
+    "enabled": true,
+    "subscribe_connectivity": false
+  }
+}
+```

--- a/docs/vehicle/commands/doors.md
+++ b/docs/vehicle/commands/doors.md
@@ -2,7 +2,7 @@
 
 ## POST `/api/1/vehicles/{id}/command/door_unlock`
 
-Unlocks the doors to the car. Extends the handles on the S and X.
+Unlocks the doors to the car. Extends the handles on the S.
 
 ### Response
 
@@ -15,7 +15,7 @@ Unlocks the doors to the car. Extends the handles on the S and X.
 
 ## POST `/api/1/vehicles/{id}/command/door_lock`
 
-Locks the doors to the car. Retracts the handles on the S and X, if they are extended.
+Locks the doors to the car. Retracts the handles on the S, if they are extended.
 
 ### Response
 

--- a/docs/vehicle/commands/misc.md
+++ b/docs/vehicle/commands/misc.md
@@ -110,3 +110,22 @@ Download Vault Profile
   "vault": "base64_jibberish"
 }
 ```
+
+<br/>
+
+# Feature Config
+
+## GET `/api/1/users/feature_config`
+
+Get the feature config.
+
+### Response
+
+```json
+{
+  "signaling": {
+    "enabled": true,
+    "subscribe_connectivity": false
+  }
+}
+```

--- a/docs/vehicle/commands/misc.md
+++ b/docs/vehicle/commands/misc.md
@@ -58,24 +58,6 @@ This endpoint requires a singular parameter `vehicle_name`, inside of the POST b
 
 <br/>
 
-# User Information
-
-## GET `/api/1/users/me`
-
-Get your user information
-
-### Response
-
-```json
-{
-  "email": "elon@tesla.com",
-  "full_name": "Elon Musk",
-  "profile_image_url": "https://vehicle-files.prd.euw1.vn.cloud.tesla.com/profile_images/{IMG}.jpg"
-}
-```
-
-<br/>
-
 # Screenshot
 
 ## GET `/api/1/vehicles/{id}/screenshot`
@@ -90,42 +72,5 @@ This is can be triggered inside of the vehicle as well, by holding the lower lef
 ```json
 {
   "response": "teleforce-ab1c234d-1a23-12a3-12a3-ab123c456d7e"
-}
-```
-
-<br/>
-
-# Download Vault Profile
-
-> Info: This endpoint is a mystery, it returns what appears to be base64 encoded strings. When decoded it has a bunch of jibberish and then two certificates and some readable strings, and what appears to be a hash of something.
-
-## GET `/api/1/users/vault_profile`
-
-Download Vault Profile
-
-### Response
-
-```json
-{
-  "vault": "base64_jibberish"
-}
-```
-
-<br/>
-
-# Feature Config
-
-## GET `/api/1/users/feature_config`
-
-Get the feature config.
-
-### Response
-
-```json
-{
-  "signaling": {
-    "enabled": true,
-    "subscribe_connectivity": false
-  }
 }
 ```

--- a/docs/vehicle/commands/misc.md
+++ b/docs/vehicle/commands/misc.md
@@ -92,3 +92,21 @@ This is can be triggered inside of the vehicle as well, by holding the lower lef
   "response": "teleforce-ab1c234d-1a23-12a3-12a3-ab123c456d7e"
 }
 ```
+
+<br/>
+
+# Download Vault Profile
+
+> Info: This endpoint is a mystery, it returns what appears to be base64 encoded strings. When decoded it has a bunch of jibberish and then two certificates and some readable strings, and what appears to be a hash of something.
+
+## GET `/api/1/users/vault_profile`
+
+Download Vault Profile
+
+### Response
+
+```json
+{
+  "vault": "base64_jibberish"
+}
+```

--- a/ownerapi_endpoints.json
+++ b/ownerapi_endpoints.json
@@ -1,4 +1,9 @@
 {
+  "ADD_KEY": {
+    "TYPE": "POST",
+    "URI": "api/1/vehicles/{vehicle_id}/add_key",
+    "AUTH": true
+  },
   "STATUS": {
     "TYPE": "GET",
     "URI": "status",


### PR DESCRIPTION
# Changes:
- Update `ownerapi_endpoints.json` to version 4.14.3-1431, on par with the Tesla App.
- Add two endpoints to the documentation.
    - Document `/api/1/users/vault_profile`.
    - Document `/api/1/users/feature_config`.
- Split out non-vehicle related endpoints out into a sperate `user` section of the docs.
    - These were previously inside `docs/vehicle/misc.md`.
- Remove mentions of retractable/extendable Model X handles. (MX doesn't have door handles, unlike the S)
 
 ## Notes:
 
> On a seperate note, I have found what appears to be the correct way of requesting the door controls for the Palladium (refreshed/post-plaid) Model X. This was mentioned in [#600 Add Support for Model X door controls](https://github.com/timdorr/tesla-api/issues/600). 
However it is untested, as none of the participants have a Palladium MX to test this. 
It seems like it is the correct way, as it was 1. Found in the decompiled Tesla Apk. And 2. It yields a response about missing busses / not being able to wake them, which means that the endpoint was programmed to respond to this specific parameter.

> I didn't want to add this information to the docs, as it is pretty much untested, however if the repo owner (@timdorr) wants this to be added regardless, I can do that. (So leave a comment and I will add this to the PR.) 
Maybe a contributor or anyone reading this who has a Palladium MX could test it and leave a comment. Instructions below. (M3/Y Testers are also welcome to test my theory.)

> The same way we request the Model X door controls, might be the way to also unlatch the M3/Y driver door. 

## Instructions for the MX Palladium Door Controls (and maybe M3/Y door unlatch)

### POST `/api/1/vehicles/{id}/command/door_unlock`
Opens the door.
### POST `/api/1/vehicles/{id}/command/door_lock` 
Closes the door.

To control a specific door you need to add the `door` parameter along with one of the below values, as JSON into the POST body.

#### Example

```json
{
  "door": "df"
}
```

| Door                                      | Value  |
|--------------------------------|--------|
| Front door, drivers side         | df       | 
| Rear door, drivers side          | dr       | 
| Front door, passenger side   | pf       | 
| Rear door, passenger side    | pr       | 

> For the M3/Y door unlatch it might be the same but just that it always has the value `df` for the parameter.