### PR TITLE
Add misc vehicle commands to summary 📜 

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -40,6 +40,7 @@
   - [Sharing](vehicle/commands/sharing.md)
   - [Software Updates](vehicle/commands/softwareupdate.md)
   - [Calendar](vehicle/commands/calendar.md)
+  - [Miscellaneous](vehicle/commands/misc.md)
 - [Streaming](vehicle/streaming.md)
 - [Autopark/Summon](vehicle/autopark.md)
 - [Option Codes](vehicle/optioncodes.md)


### PR DESCRIPTION
# Changes:
- Add Vehicle Miscellanous Commands to the summary. (`/docs/vehicle/commands/misc.md`)

> Notes: Must have slipped in previous commits. Has gone unnoticed until now. 
The page in gitbook is also not present, it leads to github for some reason. Maybe this PR will fix it?

> EDIT: This PR will fix the absence of the misc page. As seen in the [GitBook Revision](https://tesla-api.timdorr.com/~/revisions/1XeaorGzUAFWwHgEzdRe/vehicle/commands/misc)