### PR TITLE
Update info on what `remote_boombox` is + fix gitbook page ref

### DIFF
--- a/docs/vehicle/commands/README.md
+++ b/docs/vehicle/commands/README.md
@@ -74,6 +74,6 @@ Enable or disable Sentry Mode.
 
 Synchronize a calendar with the car.
 
-{% page-ref page="misc.md" %}
+{% page-ref page="./misc.md" %}
 
 Miscellaneous features. (Changing vehicle name etc.)

--- a/docs/vehicle/commands/misc.md
+++ b/docs/vehicle/commands/misc.md
@@ -83,6 +83,11 @@ This is can be triggered inside of the vehicle as well, by holding the lower lef
 
 ## POST `/api/1/vehicles/{id}/command/remote_boombox`
 
-{% hint style='info' %}
-Note: this does not seem to be enabled/implemented yet. What it does is also a mystery. My best guess is that it triggers the selected sound to play on the vehicle's PWS speaker.
-{% endhint %}
+Let the car fart remotely on version 2022.44.25.1 and above.
+
+```json
+{
+  "result": true,
+  "reason": ""
+}
+```

--- a/docs/vehicle/commands/misc.md
+++ b/docs/vehicle/commands/misc.md
@@ -85,6 +85,8 @@ This is can be triggered inside of the vehicle as well, by holding the lower lef
 
 Let the car fart remotely on version 2022.44.25.1 and above.
 
+### Response
+
 ```json
 {
   "result": true,


### PR DESCRIPTION
# Changes:
- Add information about what the `remote_boombox` endpoint does. 
    - This is the 2022.44.25.1 update's "remote fart" feature for the app. (Emissions Testing Mode via Mobile App)
- Add `./` before `misc.md` page ref, so GitBook does not link to GitHub but rather the page on GitBook itself. 
> This can be removed later, but it seems to fix the wrong page ref.

This also resolves Issue #668 