### PR TITLE
Make endpoints file link an actual link in GitBook

### DIFF
--- a/docs/miscellaneous/endpoints.md
+++ b/docs/miscellaneous/endpoints.md
@@ -1,3 +1,3 @@
 # Endpoints File
 
-The latest endpoints file as of version 4.13.3 of the mobile apps is located here: https://github.com/timdorr/tesla-api/blob/master/ownerapi_endpoints.json
+The latest endpoints file as of version 4.13.3 of the mobile apps is located here: [https://github.com/timdorr/tesla-api/blob/master/ownerapi_endpoints.json](https://github.com/timdorr/tesla-api/blob/master/ownerapi_endpoints.json)


### PR DESCRIPTION
# Changes:
- Convert sole link to ``[name](link)`` markdown schema, so it is clickable in gitbook.

## Notes:
1. Alternative to this link could be a gitbook button, so it looks better. 
2. Another alternative is making the page be a link to the endpoints file on GH, instead of it being an almost empty page with already pretty clear/known information.
> Let me know and I will update this PR to be one or the other.

----

## Option 1 Preview:

### `docs/miscellaneous/endpoints.md`

```diff
- The latest endpoints file as of version 4.13.3 of the mobile apps is located here: https://github.com/timdorr/tesla-api/blob/master/ownerapi_endpoints.json
+ The latest endpoints file as of version 4.13.3 of the mobile apps is located here:
+ {% page-ref page="https://github.com/timdorr/tesla-api/blob/master/ownerapi_endpoints.json" %}
```

----

## Option 2 Preview:

### `docs/SUMMARY.md`

```diff
- - [Endpoints File](miscellaneous/endpoints.md)
+ * [Endpoints File](https://github.com/timdorr/tesla-api/blob/master/ownerapi\_endpoints.json)
```

### `docs/miscellaneous/endpoints.md`

```diff
- This file was deleted.
```