### PR TITLE
Update climate.md

### DIFF
--- a/docs/vehicle/commands/climate.md
+++ b/docs/vehicle/commands/climate.md
@@ -228,7 +228,7 @@ These parameters need to be passed via the post body as `JSON`.
 | Body Parameter     | Example | Description                              |
 | :----------------- | :------ | :--------------------------------------- |
 | auto_seat_position | 0       | The desired seat for auto climate. (0-5) |
-| auto_climate_on    | 3       | `true` to enable and `false` to disable. |
+| auto_climate_on    | true    | `true` to enable and `false` to disable. |
 
 The `auto_seat_position` parameter maps to the following seats:
 


### PR DESCRIPTION
There is an error in the header of the remote_auto_seat_climate_request documentation. The example value for the auto_climate_on parameter should be either true or false, not 3 as currently shown