### PR TITLE
Adds Ruby 3.1 and 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Adds Ruby 3.1 and 3.2 to the CI matrix.

Runs green on my fork.