### PR TITLE
Fix link inside tripplan.md

### DIFF
--- a/docs/api-basics/tripplan.md
+++ b/docs/api-basics/tripplan.md
@@ -6,7 +6,7 @@ description: Endpoints for Trip Planner
 
 Plans a route based on the vehicle specifications and charge state. Trips that require charging will set waypoints based on Tesla Supercharger locations along the route.
 
-- [Share trip to car](vehicle/commands/sharing.md)
+- [Share trip to car](/vehicle/commands/sharing.md)
 
 ## POST `trip-planner/api/v1/tripplan`
 


### PR DESCRIPTION
# Changes:
- fix the link inside tripplan.md to lead to the actual doc instead of a 404 github page