### PR TITLE
Add depraction notices to `data_request` endpoints + update `set_vehicle_name` hint to reflect new changes/app

### DIFF
--- a/docs/vehicle/commands/misc.md
+++ b/docs/vehicle/commands/misc.md
@@ -34,8 +34,9 @@ This endpoint requires a singular parameter `note`, inside the POST body with th
 # Set Vehicle Name
 
 {% hint style='info' %}
-This endpoint currently returns `not_supported` as a response, due to not being implemented / enabled yet.
-As of app version 4.19.0-1639, this endpoint can no longer be found inside the `ownerapi_endpoints.json` file.
+Previously the endpoint returned `not_supported` as a response, due to not being implemented / enabled yet.
+Later in app version 4.19.0-1639, the endpoint was removed from the `ownerapi_endpoints.json` file.
+As of App version 4.20.5 you can change your vehicle name on software versions 2023.12+
 {% endhint %}
 
 ## POST `/api/1/vehicles/{id}/command/set_vehicle_name`

--- a/docs/vehicle/state/README.md
+++ b/docs/vehicle/state/README.md
@@ -6,7 +6,7 @@ description: These endpoints give the state of the various subsystems of the car
 
 {% page-ref page="data.md" %}
 
-{% hint style='warning' %} All `data_request` endpoints have been depracted in favour of the `vehicle_data` endpoint. All of them are found in the response of `vehicle_data` within sub-categories and the documentation of these/what the different fields mean, still applies. {% endhint %}
+{% hint style='warning' %} All `data_request` endpoints have been depracted in favour of the `vehicle_data` endpoint. All of the data they return is found in the response of `vehicle_data` within sub-categories and the documentation of these/what the different fields mean, still applies. {% endhint %}
 
 A rollup of all the `data_request` endpoints plus vehicle configuration.
 

--- a/docs/vehicle/state/README.md
+++ b/docs/vehicle/state/README.md
@@ -6,7 +6,9 @@ description: These endpoints give the state of the various subsystems of the car
 
 {% page-ref page="data.md" %}
 
-{% hint style='warning' %} All `data_request` endpoints have been depracted in favour of the `vehicle_data` endpoint. All of the data they return is found in the response of `vehicle_data` within sub-categories and the documentation of these/what the different fields mean, still applies. {% endhint %}
+{% hint style='warning' %}
+All `data_request` endpoints have been deprecated in favor of the `vehicle_data` endpoint. All of the data they return is found in the response of `vehicle_data` within sub-categories and the documentation of these/what the different fields mean, still applies.
+{% endhint %}
 
 A rollup of all the `data_request` endpoints plus vehicle configuration.
 

--- a/docs/vehicle/state/README.md
+++ b/docs/vehicle/state/README.md
@@ -6,6 +6,8 @@ description: These endpoints give the state of the various subsystems of the car
 
 {% page-ref page="data.md" %}
 
+{% hint style='warning' %} All `data_request` endpoints have been depracted in favour of the `vehicle_data` endpoint. All of them are found in the response of `vehicle_data` within sub-categories and the documentation of these/what the different fields mean, still applies. {% endhint %}
+
 A rollup of all the `data_request` endpoints plus vehicle configuration.
 
 {% page-ref page="chargestate.md" %}

--- a/docs/vehicle/state/chargestate.md
+++ b/docs/vehicle/state/chargestate.md
@@ -1,6 +1,8 @@
 # Charge State
 
-{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+{% hint style='warning' %}
+This endpoint was deprecated and returns 404.
+{% endhint %}
 
 ## GET `/api/1/vehicles/{id}/data_request/charge_state`
 

--- a/docs/vehicle/state/chargestate.md
+++ b/docs/vehicle/state/chargestate.md
@@ -1,5 +1,7 @@
 # Charge State
 
+{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+
 ## GET `/api/1/vehicles/{id}/data_request/charge_state`
 
 Information on the state of charge in the battery and its various settings.

--- a/docs/vehicle/state/climatestate.md
+++ b/docs/vehicle/state/climatestate.md
@@ -1,5 +1,7 @@
 # Climate State
 
+{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+
 ## GET `/api/1/vehicles/{id}/data_request/climate_state`
 
 Information on the current internal temperature and climate control system.

--- a/docs/vehicle/state/climatestate.md
+++ b/docs/vehicle/state/climatestate.md
@@ -1,6 +1,8 @@
 # Climate State
 
-{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+{% hint style='warning' %}
+This endpoint was deprecated and returns 404.
+{% endhint %}
 
 ## GET `/api/1/vehicles/{id}/data_request/climate_state`
 

--- a/docs/vehicle/state/data.md
+++ b/docs/vehicle/state/data.md
@@ -215,6 +215,8 @@ Currently, this has the exact same response structure as the newer vehicle_data 
 
 ## GET `/api/1/vehicles/{id}/latest_vehicle_data`
 
+{% hint style='warning' %} This endpoint was depracted in favour of the `vehicle_data` endpoint and returns 404. {% endhint %}
+
 This is cached data, pushed by the vehicle on sleep, wake and around OTAs.
 
 ### Response

--- a/docs/vehicle/state/data.md
+++ b/docs/vehicle/state/data.md
@@ -215,7 +215,9 @@ Currently, this has the exact same response structure as the newer vehicle_data 
 
 ## GET `/api/1/vehicles/{id}/latest_vehicle_data`
 
-{% hint style='warning' %} This endpoint was depracted in favour of the `vehicle_data` endpoint and returns 404. {% endhint %}
+{% hint style='warning' %}
+This endpoint was deprecated in favor of the `vehicle_data` endpoint and returns 404.
+{% endhint %}
 
 This is cached data, pushed by the vehicle on sleep, wake and around OTAs.
 

--- a/docs/vehicle/state/drivestate.md
+++ b/docs/vehicle/state/drivestate.md
@@ -1,5 +1,7 @@
 # Drive State
 
+{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+
 ## GET `/api/1/vehicles/{id}/data_request/drive_state`
 
 Returns the driving and position state of the vehicle.

--- a/docs/vehicle/state/drivestate.md
+++ b/docs/vehicle/state/drivestate.md
@@ -1,6 +1,8 @@
 # Drive State
 
-{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+{% hint style='warning' %}
+This endpoint was deprecated and returns 404.
+{% endhint %}
 
 ## GET `/api/1/vehicles/{id}/data_request/drive_state`
 

--- a/docs/vehicle/state/guisettings.md
+++ b/docs/vehicle/state/guisettings.md
@@ -1,5 +1,7 @@
 # GUI Settings
 
+{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+
 ## GET `/api/1/vehicles/{id}/data_request/gui_settings`
 
 Returns various information about the GUI settings of the car, such as unit format and range display.

--- a/docs/vehicle/state/guisettings.md
+++ b/docs/vehicle/state/guisettings.md
@@ -1,6 +1,8 @@
 # GUI Settings
 
-{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+{% hint style='warning' %}
+This endpoint was deprecated and returns 404.
+{% endhint %}
 
 ## GET `/api/1/vehicles/{id}/data_request/gui_settings`
 

--- a/docs/vehicle/state/vehicleconfig.md
+++ b/docs/vehicle/state/vehicleconfig.md
@@ -1,6 +1,8 @@
 # Vehicle Config
 
-{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+{% hint style='warning' %}
+This endpoint was deprecated and returns 404.
+{% endhint %}
 
 ## GET `/api/1/vehicles/{id}/data_request/vehicle_config`
 

--- a/docs/vehicle/state/vehicleconfig.md
+++ b/docs/vehicle/state/vehicleconfig.md
@@ -1,5 +1,7 @@
 # Vehicle Config
 
+{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+
 ## GET `/api/1/vehicles/{id}/data_request/vehicle_config`
 
 Returns the vehicle's configuration information including model, color, badging and wheels.

--- a/docs/vehicle/state/vehiclestate.md
+++ b/docs/vehicle/state/vehiclestate.md
@@ -1,5 +1,7 @@
 # Vehicle State
 
+{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+
 ## GET `/api/1/vehicles/{id}/data_request/vehicle_state`
 
 Returns the vehicle's physical state, such as which doors are open.

--- a/docs/vehicle/state/vehiclestate.md
+++ b/docs/vehicle/state/vehiclestate.md
@@ -1,6 +1,8 @@
 # Vehicle State
 
-{% hint style='warning' %} This endpoint was depracted and returns 404. {% endhint %}
+{% hint style='warning' %}
+This endpoint was deprecated and returns 404.
+{% endhint %}
 
 ## GET `/api/1/vehicles/{id}/data_request/vehicle_state`
 


### PR DESCRIPTION
# Changes:
- Update information/hint on the `set_vehicle_name` endpoint as it was enabled/added to the app in v4.20.75 & vehicle SW 2023.12+
- Add depraction notice to `chargestate.md`
- Add depraction notice to `climatestate.md`
- Add depraction notice to `drivestate.md`
- Add depraction notice to `guisettings.md`
- Add depraction notice to `vehicleconfig.md`
- Add depraction notice to `vehiclestate.md`
- Add depraction notice to `data.md` which outlines, that the `latest_vehicle_data` endpoint has been depracted in favour of the `vehicle_data` endpoint.
- Add general depraction notice to `README.md` which outlines, that all `data_request` endpoints have been depracted, their information put into the `vehicle_data` endpoint and that the documentation for the different JSON fields still applies.

> Note: I was unable to obtain the new versions (`v4.20.75`) endpoint file/apk or ipa. If I do I will follow up with another PR.
> Currently on par with app `v4.20.70`