### PR TITLE
Update `remote_boombox` with prep for Boombox V2

### DIFF
--- a/docs/vehicle/commands/misc.md
+++ b/docs/vehicle/commands/misc.md
@@ -85,7 +85,23 @@ This is can be triggered inside of the vehicle as well, by holding the lower lef
 
 ## POST `/api/1/vehicles/{id}/command/remote_boombox`
 
-Let the car fart remotely on version 2022.44.25.1 and above.
+Let the car fart remotely on version 2022.44.25.1 and above or use boombox v2 on supported vehicles.
+
+### Parameters
+
+This endpoint does not require a POST body to fart remotely but needs one to use boombox v2.
+
+| Parameter | Example | Description |
+| :-------- | :------ | :---------- |
+| action    | 0       | Fart        |
+
+### Example
+
+```json
+{
+  "action": 0
+}
+```
 
 ### Response
 

--- a/docs/vehicle/commands/misc.md
+++ b/docs/vehicle/commands/misc.md
@@ -91,9 +91,15 @@ Let the car fart remotely on version 2022.44.25.1 and above or use boombox v2 on
 
 This endpoint does not require a POST body to fart remotely but needs one to use boombox v2.
 
-| Parameter | Example | Description |
-| :-------- | :------ | :---------- |
-| action    | 0       | Fart        |
+| Parameter | Example | Description                             |
+| :-------- | :------ | :-------------------------------------- |
+| action    | 0       | Numerical value representing the action |
+
+The available actions are:
+
+| Action | Corresponding numerical value |
+| :----- | :---------------------------- |
+| Fart   | 0                             |
 
 ### Example
 


### PR DESCRIPTION
# Changes:
- Update the documentation regarding the `remote_boombox` command.
   - Add docs about the body parameter and boombox actions as prep for boombox V2.

> More actions need to be added as Tesla rolls out BBX V2, this is just the preperation for when this change strikes and the app has already been observed to send the post body when the "remote fart button" is clicked.
----
<details>
  <summary><h1>New docs/doc update</h1></summary>

# Remote Boombox

## POST `/api/1/vehicles/{id}/command/remote_boombox`

Let the car fart remotely on version 2022.44.25.1 and above or use boombox v2 on supported vehicles.

### Parameters

This endpoint does not require a POST body to fart remotely but needs one to use boombox v2.

| Parameter | Example | Description                             |
| :-------- | :------ | :-------------------------------------- |
| action    | 0       | Numerical value representing the action |

The available actions are:

| Action | Corresponding numerical value |
| :----- | :---------------------------- |
| Fart   | 0                             |

### Example

```json
{
  "action": 0
}
```

### Response

```json
{
  "result": true,
  "reason": ""
}
```
</details>

<details>
  <summary><h1>Old docs</h1></summary>

# Remote Boombox

## POST `/api/1/vehicles/{id}/command/remote_boombox`

Let the car fart remotely on version 2022.44.25.1 and above.

### Response

```json
{
  "result": true,
  "reason": ""
}
```


</details>