### PR TITLE
Allow Faraday logging

### DIFF
--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -15,6 +15,8 @@ module TeslaApi
       retry_options: nil,
       base_uri: nil,
       sso_uri: nil,
+      logger_bodies: false,
+      logger_headers: false,
       client_options: {headers: {"Accept" => "application/json"}}
     )
       @email = email
@@ -37,6 +39,7 @@ module TeslaApi
         conn.response :json
         conn.response :raise_error
         conn.request :retry, retry_options if retry_options # Must be registered after :raise_error
+        conn.response :logger, ::Logger.new($stdout), bodies: logger_bodies, headers: logger_headers if logger_bodies || logger_headers
         conn.adapter Faraday.default_adapter
       }
     end

--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -34,7 +34,6 @@ module TeslaApi
         @base_uri + "/api/1",
         client_options
       ) { |conn|
-        # conn.response :logger, nil, {headers: true, bodies: true}
         conn.request :json
         conn.response :json
         conn.response :raise_error


### PR DESCRIPTION
`Tesla::Client.new(logger_bodies: true, logger_header: true)` enables Faraday logger

The Faraday client cannot be modified after its constructed; so I believe we need to allow enabling logging middleware during `Tesla::Client.new` constructor.