### PR TITLE
Drop faraday_middleware in favour of native faraday 2.x

### DIFF
--- a/lib/tesla_api.rb
+++ b/lib/tesla_api.rb
@@ -2,7 +2,7 @@ require "date"
 require "base64"
 
 require "faraday"
-require "faraday_middleware"
+require "faraday/retry"
 
 require "async"
 require "async/http/endpoint"

--- a/lib/tesla_api/version.rb
+++ b/lib/tesla_api/version.rb
@@ -1,3 +1,3 @@
 module TeslaApi
-  VERSION = "3.1.0"
+  VERSION = "3.2.0"
 end

--- a/tesla_api.gemspec
+++ b/tesla_api.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "async-websocket"
-  spec.add_dependency "faraday"
-  spec.add_dependency "faraday_middleware"
+  spec.add_dependency "base64"
+  spec.add_dependency "faraday", ">= 2.0"
+  spec.add_dependency "faraday-retry", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
`faraday_middleware` is gedeprecated en houdt deze gem op de 1.x-lijn van faraday — daardoor blijven downstream consumers (zoals `stekker/stekker` `StekkerSim/Gemfile.lock`) hangen op faraday 0.17.3 met de Dependabot-DoS-melding rond `NestedParamsEncoder`.

Wijzigingen:
- gemspec eist `faraday >= 2.0` en `faraday-retry ~> 2.0` direct (geen `faraday_middleware` meer).
- `:json` request- en response-middleware zitten sinds faraday 2.0 in core, dus de aparte `require "faraday_middleware"` is vervangen door `require "faraday/retry"`.
- `base64` als expliciete dependency zodat de gem op Ruby 3.4+ blijft werken (base64 zit daar niet meer in de default-gems-set).
- Version naar 3.2.0 omdat dit een breaking change is voor consumers die op faraday 0.x of 1.x hangen.

Smoke test bevestigt dat `TeslaApi::Client.new(...)` zowel met als zonder `retry_options` de juiste middleware-stack opbouwt op faraday 2.14.3.

De rspec-suite hangt aan VCR cassettes met `ENV["TESLA_EMAIL"]` etc. placeholders; zonder die credentials falen de integratietesten al op master en dat is dus geen regressie van dit PR.